### PR TITLE
Build casacore 3.5.0 on macOS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,17 @@
 name: brew pr-pull
+
 on:
   pull_request_target:
     types:
       - labeled
+
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -18,7 +23,7 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -30,4 +35,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{ github.token }}
-          branch: main
+          branch: master
 
       - name: Delete branch
         if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: brew test-bot
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,16 @@
 name: brew test-bot
+
 on:
   push:
-    branches: main
+    branches:
+      - main
   pull_request:
+
 jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-22.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -15,16 +18,11 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
 
       - run: brew test-bot --only-cleanup-before
 
@@ -37,7 +35,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/Formula/casacore-data.rb
+++ b/Formula/casacore-data.rb
@@ -8,8 +8,8 @@ end
 class CasacoreData < Formula
   desc "Ephemerides and geodetic data for casacore measures (via Astron)"
   homepage "https://github.com/casacore/casacore"
-  url "ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures_20240325-160001.ztar", using: ZtarDownloadStrategy
-  sha256 "8cd94f300bba7c6776211b579ca88fea1be131c063850d9a9cf9234b8d709ab2"
+  url "ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures_20240611-160001.ztar", using: ZtarDownloadStrategy
+  sha256 "2241bae966986bb7914d589084fb69e4844ef5813d7189eb414370e0583f67d2"
   head "ftp://ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar", using: ZtarDownloadStrategy
 
   option "with-casapy", "Use Mac CASA.App (aka casapy) data directory if found"

--- a/Formula/casacore.rb
+++ b/Formula/casacore.rb
@@ -1,8 +1,8 @@
 class Casacore < Formula
   desc "Suite of C++ libraries for radio astronomy data processing"
   homepage "https://github.com/casacore/casacore"
-  url "https://github.com/casacore/casacore/archive/refs/tags/v3.4.0.tar.gz"
-  sha256 "31f02ad2e26f29bab4a47a2a69e049d7bc511084a0b8263360e6157356f92ae1"
+  url "https://github.com/casacore/casacore/archive/refs/tags/v3.5.0.tar.gz"
+  sha256 "63f1c8eff932b0fcbd38c598a5811e6e5397b72835b637d6f426105a183b3f91"
   head "https://github.com/casacore/casacore.git"
 
   option "with-python", "Build Python bindings"
@@ -11,7 +11,8 @@ class Casacore < Formula
   depends_on "casacore-data"
   depends_on "cfitsio"
   depends_on "fftw"
-  depends_on "gcc" # for gfortran
+  depends_on "gcc"  # for gfortran
+  depends_on "gsl"
   depends_on "hdf5"
   depends_on "readline"
   depends_on "wcslib"
@@ -33,7 +34,6 @@ class Casacore < Formula
       cmake_args = std_cmake_args
       cmake_args.delete "-DCMAKE_BUILD_TYPE=None"
       cmake_args << "-DCMAKE_BUILD_TYPE=#{build_type}"
-      cmake_args << "-DBUILD_PYTHON=OFF"
       cmake_args << "-DBUILD_PYTHON3=#{build.with?("python") ? "ON" : "OFF"}"
       cmake_args << "-DUSE_OPENMP=OFF"
       cmake_args << "-DUSE_FFTW3=ON" << "-DFFTW3_ROOT_DIR=#{HOMEBREW_PREFIX}"

--- a/Formula/casacore.rb
+++ b/Formula/casacore.rb
@@ -17,6 +17,8 @@ class Casacore < Formula
   depends_on "readline"
   depends_on "wcslib"
 
+  # Apply patches at the end of the formula, in the following order:
+  # 1. casacore/casacore#1350 (should be in next release after 3.5.0)
   patch :DATA
 
   if build.with?("python")
@@ -52,15 +54,14 @@ class Casacore < Formula
 end
 
 __END__
-diff --git a/python/Converters/test/CMakeLists.txt b/python/Converters/test/CMakeLists.txt
-index 32214a8..321c98b 100644
---- a/python/Converters/test/CMakeLists.txt
-+++ b/python/Converters/test/CMakeLists.txt
-@@ -1,6 +1,6 @@
- include_directories ("..")
- add_library(tConvert MODULE tConvert.cc)
- SET_TARGET_PROPERTIES(tConvert PROPERTIES PREFIX "_") 
--target_link_libraries (tConvert casa_python ${PYTHON_LIBRARIES})
-+target_link_libraries (tConvert casa_python)
- add_test (tConvert ${CMAKE_SOURCE_DIR}/cmake/cmake_assay ./tConvert)
- add_dependencies(check tConvert)
+diff --git a/tables/Dysco/tests/testdyscostman.cc b/tables/Dysco/tests/testdyscostman.cc
+index 69da97c..ae52c03 100644
+--- a/tables/Dysco/tests/testdyscostman.cc
++++ b/tables/Dysco/tests/testdyscostman.cc
+@@ -1,5 +1,6 @@
+ #include <boost/test/unit_test.hpp>
+ #include <boost/filesystem/operations.hpp>
++#include <boost/filesystem/directory.hpp>
+ 
+ #include <casacore/tables/Tables/ArrayColumn.h>
+ #include <casacore/tables/Tables/Table.h>

--- a/Formula/casacore.rb
+++ b/Formula/casacore.rb
@@ -11,7 +11,7 @@ class Casacore < Formula
   depends_on "casacore-data"
   depends_on "cfitsio"
   depends_on "fftw"
-  depends_on "gcc"  # for gfortran
+  depends_on "gcc" # for gfortran
   depends_on "gsl"
   depends_on "hdf5"
   depends_on "readline"

--- a/Formula/casacore.rb
+++ b/Formula/casacore.rb
@@ -5,7 +5,7 @@ class Casacore < Formula
   sha256 "63f1c8eff932b0fcbd38c598a5811e6e5397b72835b637d6f426105a183b3f91"
   head "https://github.com/casacore/casacore.git"
 
-  option "with-python", "Build Python bindings"
+  option "without-python", "Build without Python bindings"
 
   depends_on "cmake" => :build
   depends_on "casacore-data"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Or `brew tap casacore/tap` and then `brew install <formula>`.
 
 ## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+
+## History
+
+This used to reside in https://github.com/ska-sa/homebrew-tap.
+
+To access those older commits when you run `git log`, `git blame` and
+other commands on your local clone, do
+
+`git fetch origin '+refs/replace/*:refs/replace/*'`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 
 Or `brew tap casacore/tap` and then `brew install <formula>`.
 
+Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
+
+```ruby
+tap "test/tap"
+brew "<formula>"
+```
+
 ## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
 


### PR DESCRIPTION
- Build the released casacore 3.5.0.
- I had to include the casacore/casacore#1350 fix as a temporary patch. I also removed an old Python 2 patch. We should be patch-free after the next release 🙂
- Build Python bindings by default now, as I keep on forgetting to specify it. Who doesn't need it anyway? The upside is that we can now have Python-enabled bottles for the first time  🎉 
- Upgraded the Homebrew actions so that tests pass and we have bottles (ventura-intel and sonoma-arm).
- Updated `casacore-data` measures, for what it's worth.
- Advertise my nifty historical graft to make older commits visible during logs and blames.
